### PR TITLE
Update utils.ts

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -163,7 +163,10 @@ export class HookFetchRequest<T = unknown, E = unknown> implements PromiseLike<T
       let err = null;
       for (const plugin of beforeRequestPlugins) {
         try {
-          config = (await plugin(config)) as RequestConfig<unknown, unknown, E>;
+          config = (await plugin(config))
+          if(config instanceof Response){
+            resolve(config)
+          }
         }
         catch (error) {
           err = error;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -163,7 +163,7 @@ export class HookFetchRequest<T = unknown, E = unknown> implements PromiseLike<T
       let err = null;
       for (const plugin of beforeRequestPlugins) {
         try {
-          config = (await plugin(config))
+          config = (await plugin(config)) as RequestConfig<unknown, unknown, E>|Response
           if(config instanceof Response){
             resolve(config)
           }


### PR DESCRIPTION
禁用强制类型转换，判断返回类型为Response时，直接返回Response，适用于缓存接口。
```js
    return {
        name: 'cache',
        async beforeRequest(requestConfig) {
            console.log(requestConfig.headers)
            if (config.excludeMethods.includes(requestConfig.method)) {
                return requestConfig
            }
            const key = getRequestKey(
                requestConfig.url,
                requestConfig.method,
                requestConfig.params,
                requestConfig.data,
            )
            const cached = cache.get(key)

            if (cached && Date.now() - cached.timestamp < config.ttl) {
                // 返回缓存数据
                return new Response(JSON.stringify(cached.data), {
                    status: 302,
                    headers: {
                        'Content-Type': 'application/json',
                    },
                })
            }

            return requestConfig
        },
        async afterResponse(context, requestConfig) {
            if (config.excludeMethods.includes(requestConfig.method)) {
                return context
            }

            const key = getRequestKey(
                requestConfig.url,
                requestConfig.method,
                requestConfig.params,
                requestConfig.data,
            )
            // 限制缓存大小
            if (cache.size >= config.maxSize) {
                const firstKey = cache.keys().next().value
                cache.delete(firstKey)
            }
            if (requestConfig.headers.isCache) {
                info(`Cache afterResponse: ${context}`)
                // 缓存响应
                cache.set(key, {
                    data: context.result,
                    timestamp: Date.now(),
                })
            }
            return context
        },
...
```